### PR TITLE
Custom runtime macro annotations

### DIFF
--- a/rtic-core/src/backend.rs
+++ b/rtic-core/src/backend.rs
@@ -241,4 +241,26 @@ pub trait CorePassBackend {
     fn entry_attrs(&self) -> Option<TokenStream2> {
         None
     }
+
+    /// Attribute macros to add to tasks
+    ///
+    /// Used by some implementations to inject custom pre- and postambles to task handlers.
+    ///
+    /// # Examples
+    ///
+    /// `task_attrs` allows to add attribute macros to the main entry point, enabling the following
+    /// common use case:
+    ///
+    /// ```rust
+    /// #[riscv_rt::interrupt]
+    /// fn Uart() {}
+    /// ```
+    ///
+    /// # Developer notes
+    ///
+    /// Return type `Option<proc_macro2::TokenStream2>` is too permissive. We should be returning
+    /// just `syn::Attribute` but I couldn't figure out how to effectively generate that.
+    fn task_attrs(&self) -> Option<TokenStream2> {
+        None
+    }
 }

--- a/rtic-core/src/backend.rs
+++ b/rtic-core/src/backend.rs
@@ -217,4 +217,28 @@ pub trait CorePassBackend {
 
     /// Implementation must return the default task priority to be used in idle task and tasks when priority argument value is not provided by the user.
     fn default_task_priority(&self) -> u16;
+
+    /// Attribute macros to add to the entry point
+    ///
+    /// Used often to annotate the runtime entry point for bare metal applications.
+    ///
+    /// # Examples
+    ///
+    /// `entry_attrs` allows to add attribute macros to the main entry point, enabling the following
+    /// common use case:
+    ///
+    /// ```rust
+    /// #[riscv_rt::entry]
+    /// fn main() -> ! {
+    ///     loop {}
+    /// }
+    /// ```
+    ///
+    /// # Developer notes
+    ///
+    /// Return type `Option<proc_macro2::TokenStream2>` is too permissive. We should be returning
+    /// just `syn::Attribute` but I couldn't figure out how to effectively generate that.
+    fn entry_attrs(&self) -> Option<TokenStream2> {
+        None
+    }
 }

--- a/rtic-core/src/codegen/hw_task.rs
+++ b/rtic-core/src/codegen/hw_task.rs
@@ -90,7 +90,7 @@ impl RticTask {
 /// if "multibin" feature is enabled we need to process the task impl further.
 /// Only the core that runs the task should contain the task trait implementation (init() and exec()).
 /// However, because all the cores have a copy of the task struct (which must implement the task trait .. chicken-egg problem),
-/// we solve this problem by reducing as much code as possible for the other cores by emptying their implemented functions.  
+/// we solve this problem by reducing as much code as possible for the other cores by emptying their implemented functions.
 #[cfg(feature = "multibin")]
 fn process_task_impl(task_impl: &syn::ItemImpl, core: u32) -> TokenStream2 {
     let cfg_core =
@@ -125,6 +125,7 @@ impl HardwareTask {
         implementation: &dyn CorePassBackend,
     ) -> Option<TokenStream2> {
         let cfg_core = multibin::multibin_cfg_core(self.args.core);
+        let task_attrs = implementation.task_attrs().unwrap_or(quote!());
         let task_static_handle = &self.name_uppercase();
         let task_irq_handler = &self.args.interrupt_handler_name.clone()?;
 
@@ -140,6 +141,7 @@ impl HardwareTask {
             #cfg_core
             #[allow(non_snake_case)]
             #[no_mangle]
+            #task_attrs
             fn #task_irq_handler() {
                 #task_dispatch_call
             }

--- a/rtic-core/src/codegen/mod.rs
+++ b/rtic-core/src/codegen/mod.rs
@@ -166,6 +166,7 @@ impl<'a> CodeGen<'a> {
             // priority masks
             let priority_masks = implementation.generate_global_definitions(args, app, analysis);
             let entry_name = implementation.set_entry_name(app.core);
+            let entry_attrs = implementation.entry_attrs().unwrap_or(quote!());
 
             let interrupt_free = format_ident!("{}", INTERRUPT_FREE_FN);
 
@@ -199,6 +200,7 @@ impl<'a> CodeGen<'a> {
                 #[doc = r" Entry of "]
                 #[doc = #doc]
                 #cfg_core
+                #entry_attrs
                 #[no_mangle]
                 pub fn #entry_name() -> ! {
                     // Disable interrupts during initialization


### PR DESCRIPTION
Enables injecting macros into program entry point & task handlers.

Let me know how you feel about this change.