### PR TITLE
core: allow RTIC attributes without assignment

### DIFF
--- a/rtic-core/src/parse_utils/mod.rs
+++ b/rtic-core/src/parse_utils/mod.rs
@@ -46,7 +46,11 @@ impl RticAttr {
     pub fn parse_from_tokens(tokens: &TokenStream2) -> syn::Result<Self> {
         let mut elements = HashMap::new();
         syn::meta::parser(|meta| {
-            let value: syn::Expr = meta.value()?.parse()?;
+            let value: syn::Expr = meta
+                .value()
+                // Try parsing the assignment operator. On failure, set value = ().
+                .map(|v| v.parse())
+                .unwrap_or_else(|_| Ok(parse_quote!(())))?;
             if let Some(ident) = meta.path.get_ident() {
                 elements.insert(ident.to_string(), value);
             }

--- a/rtic-core/src/parser/ast.rs
+++ b/rtic-core/src/parser/ast.rs
@@ -4,8 +4,8 @@ use heck::ToSnakeCase;
 use proc_macro2::Span;
 use quote::{format_ident, ToTokens};
 use syn::{
-    parse::Parser, spanned::Spanned, Expr, ExprArray, ExprLit, Ident, ItemFn, ItemImpl, ItemStruct,
-    Lit, LitInt, Meta,
+    parse::Parser, parse_quote, spanned::Spanned, Expr, ExprArray, ExprLit, Ident, ItemFn,
+    ItemImpl, ItemStruct, Lit, LitInt, Meta,
 };
 
 use crate::{
@@ -92,7 +92,11 @@ impl TaskArgs {
                 task_trait = Some(meta.value()?.parse()?);
             } else {
                 // this is needed to advance the values iterator
-                let _: syn::Result<Expr> = meta.value()?.parse();
+                let _: syn::Result<Expr> = meta
+                    .value()
+                    // Try parsing the assignment operator. On failure, set value = ().
+                    .map(|v| v.parse())
+                    .unwrap_or_else(|_| Ok(parse_quote!(())));
             }
             Ok(())
         })


### PR DESCRIPTION
E.g., attributes of the form: `fast` instead of `priority = 5`. For Atalanta PCS pass, obviously.

There's probably a better way than how I implemented it. My implementation here tries to parse the assignment, and if that doesn't work out, sets the value to unit type (`()`). This allows attributes such as `#[fast]` to fall through.