### PR TITLE
Pass lock-closure return value to caller

### DIFF
--- a/distributions/atalanta-rtic/rtic-macro/src/lib.rs
+++ b/distributions/atalanta-rtic/rtic-macro/src/lib.rs
@@ -133,7 +133,7 @@ impl CorePassBackend for AtalantaRtic {
     ) -> syn::ImplItemFn {
         let lock_impl: syn::Block = parse_quote! {
             {
-                unsafe { rtic::export::lock(resource_ptr, task_priority as u8, CEILING as u8, f); }
+                unsafe { rtic::export::lock(resource_ptr, task_priority as u8, CEILING as u8, f) }
             }
         };
 

--- a/distributions/distribution-template/rtic-macro/src/lib.rs
+++ b/distributions/distribution-template/rtic-macro/src/lib.rs
@@ -98,7 +98,7 @@ impl StandardPassImpl for RenodeRtic {
 
         let lock_impl: syn::Block = parse_quote! {
             { 
-                unsafe { rtic::export::lock(resource_ptr, CEILING as u8, NVIC_PRIO_BITS, f); }
+                unsafe { rtic::export::lock(resource_ptr, CEILING as u8, NVIC_PRIO_BITS, f) }
             } 
         };
 

--- a/distributions/rp2040-rtic/rp2040-rtic-macro/src/lib.rs
+++ b/distributions/rp2040-rtic/rp2040-rtic-macro/src/lib.rs
@@ -166,7 +166,7 @@ impl CorePassBackend for Rp2040Rtic {
         let masks_ident = format_ident!("__rtic_internal_MASKS_core{core}"); // already computed by `compute_lock_static_args(...)`
 
         let lock_impl: syn::Block = parse_quote! {
-            { unsafe { rtic::export::lock(resource_ptr, task_priority, CEILING, &#masks_ident, f); } }
+            { unsafe { rtic::export::lock(resource_ptr, task_priority, CEILING, &#masks_ident, f) } }
         };
 
         let mut completed_lock_fn = incomplete_lock_fn;

--- a/distributions/rtic-hippo/rtic-macro/src/lib.rs
+++ b/distributions/rtic-hippo/rtic-macro/src/lib.rs
@@ -102,7 +102,7 @@ impl CorePassBackend for HippoRtic {
     ) -> syn::ImplItemFn {
         let lock_impl: syn::Block = parse_quote! {
             {
-                unsafe { rtic::export::lock(resource_ptr, task_priority as u8, CEILING as u8, f); }
+                unsafe { rtic::export::lock(resource_ptr, task_priority as u8, CEILING as u8, f) }
             }
         };
 

--- a/distributions/stm32-renode-rtic/stm32-renode-rtic-macro/src/lib.rs
+++ b/distributions/stm32-renode-rtic/stm32-renode-rtic-macro/src/lib.rs
@@ -109,7 +109,7 @@ impl CorePassBackend for RenodeRtic {
     ) -> syn::ImplItemFn {
         let lock_impl: syn::Block = parse_quote! {
             {
-                unsafe { rtic::export::lock(resource_ptr, CEILING as u8, NVIC_PRIO_BITS, f); }
+                unsafe { rtic::export::lock(resource_ptr, CEILING as u8, NVIC_PRIO_BITS, f) }
             }
         };
 

--- a/rtic-core/src/backend.rs
+++ b/rtic-core/src/backend.rs
@@ -52,7 +52,7 @@ pub trait CorePassBackend {
     /// impl RticMutex for __resource1_mutex {
     ///     type ResourceType = R1Type;
     ///     // this is what the trait method argument `incomplete_lock_fn` expands to
-    ///     fn lock(&mut self, f: impl FnOnce(&mut Self::ResourceType)) {
+    ///     fn lock<R>(&mut self, f: impl FnOnce(&mut Self::ResourceType) -> R) -> R {
     ///         const CEILING: u16 = 3u16; // resource ceiling
     ///         let task_priority = self.task_priority; // current task priority
     ///         let resource_ref = unsafe { &mut SHARED.assume_init_mut().resource1 };

--- a/rtic-core/src/common_internal/rtic_functions.rs
+++ b/rtic-core/src/common_internal/rtic_functions.rs
@@ -35,7 +35,7 @@ pub(crate) fn get_resource_proxy_lock_fn(
     let ceiling = resource.priority;
     let resource_ident = &resource.ident;
     let lock_fn = parse_quote! {
-        fn lock(&mut self, f: impl FnOnce(&mut Self::ResourceType)) {
+        fn lock<R>(&mut self, f: impl FnOnce(&mut Self::ResourceType) -> R) -> R {
             // `self` refers to the resource proxy struct
 
             const CEILING: u16 = #ceiling; // resource priority ceiling

--- a/rtic-core/src/common_internal/rtic_traits.rs
+++ b/rtic-core/src/common_internal/rtic_traits.rs
@@ -56,7 +56,7 @@ fn mutex_trait() -> TokenStream2 {
     quote! {
         pub trait #mutex {
             type ResourceType;
-            fn lock(&mut self, f: impl FnOnce(&mut Self::ResourceType));
+            fn lock<R>(&mut self, f: impl FnOnce(&mut Self::ResourceType) -> R) -> R;
         }
     }
 }


### PR DESCRIPTION
Enables:

```rs
let out = self.shared().res.lock(|r| *r);
```

... instead of:

```rs
let mut out = 0;
self.shared().res.lock(|r| { out = *r; });
```

First commit makes the backend generate wrappers with the right signatures,

second commit makes sure the distributions pass the value.

Untested, but the same change compiles and works on zeroHETI :)